### PR TITLE
Cap production speed of single miner to 1800/m

### DIFF
--- a/BetterStats/BetterStats.cs
+++ b/BetterStats/BetterStats.cs
@@ -454,6 +454,9 @@ namespace BetterStats
 
         }
 
+        // speed of fasted belt(mk3 belt) is 1800 items per minute
+        public const float BELT_MAX_ITEMS_PER_MINUTE = 1800;
+
         public static void AddPlanetFactoryData(PlanetFactory planetFactory)
         {
             var factorySystem = planetFactory.factorySystem;
@@ -497,6 +500,7 @@ namespace BetterStats
                 {
                     production = frequency * speed * miner.veinCount;
                 }
+                production = Math.Min(BELT_MAX_ITEMS_PER_MINUTE, production);
 
                 counter[productId].production += production;
                 counter[productId].producers++;


### PR DESCRIPTION
With a high level of vein utilization, it's possible for a single miner to overflow capacity of a mk3 belt. Therefore, production rates >1800/m for a single miner is pointless, because you can't realize that speed anyway.