### PR TITLE
Fix theoretical max consumption rate for Universe Matrix

### DIFF
--- a/BetterStats/BetterStats.csproj
+++ b/BetterStats/BetterStats.csproj
@@ -109,7 +109,6 @@
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
-    <PostBuildEvent>copy $(TargetPath) "C:\Program Files (x86)\Steam\steamapps\common\Dyson Sphere Program\BepInEx\scripts\$(TargetFileName)"
-</PostBuildEvent>
+    <PostBuildEvent>copy $(TargetPath) "C:\Program Files (x86)\Steam\steamapps\common\Dyson Sphere Program\BepInEx\scripts\$(TargetFileName)"</PostBuildEvent>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
~I realize there is a lot going on in this PR, and maybe this stuff should just go in its own mod, but doing that makes some of the interactions a little tougher (filtering items for example).~
I moved most of the complex stuff out of this PR into a different mod. To summarize the changes made.

- Updated counter to record the theoretical max consumption rate for Universe Matrix
- Updated the display/s checkbox to be persisted as a config property.